### PR TITLE
ExternalActor Endpoints Rebase

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,7 +1,13 @@
 [mypy]
 python_version = 3.6
-files = src/sentry/api/endpoints/project_codeowners.py,
+files = src/sentry/api/bases/external_actor.py,
+        src/sentry/api/endpoints/project_codeowners.py,
+        src/sentry/api/endpoints/external_team.py,
+        src/sentry/api/endpoints/external_team_details.py,
+        src/sentry/api/endpoints/external_user.py,
+        src/sentry/api/endpoints/external_user_details.py,
         src/sentry/api/serializers/base.py,
+        src/sentry/api/serializers/models/external_actor.py,
         src/sentry/api/serializers/models/integration.py,
         src/sentry/api/serializers/models/notification_setting.py,
         src/sentry/api/serializers/models/organization_member.py,

--- a/src/sentry/api/bases/external_actor.py
+++ b/src/sentry/api/bases/external_actor.py
@@ -1,0 +1,121 @@
+from typing import Any, MutableMapping
+
+from django.db import IntegrityError
+from django.http import Http404
+from rest_framework import serializers  # type: ignore
+from rest_framework.exceptions import PermissionDenied  # type: ignore
+from rest_framework.request import Request  # type: ignore
+
+from sentry import features
+from sentry.api.serializers.rest_framework.base import CamelSnakeModelSerializer
+from sentry.api.validators.integrations import validate_provider
+from sentry.models import ExternalActor, Organization, Team, User
+from sentry.types.integrations import ExternalProviders, get_provider_choices
+
+AVAILABLE_PROVIDERS = {
+    ExternalProviders.GITHUB,
+    ExternalProviders.GITLAB,
+    ExternalProviders.SLACK,
+}
+
+
+class ExternalActorSerializerBase(CamelSnakeModelSerializer):  # type: ignore
+    external_id = serializers.CharField()
+    external_name = serializers.CharField(required=True)
+    provider = serializers.ChoiceField(choices=get_provider_choices(AVAILABLE_PROVIDERS))
+
+    @property
+    def organization(self) -> Organization:
+        return self.context["organization"]
+
+    def get_actor_id(self, validated_data: MutableMapping[str, Any]) -> int:
+        return int(validated_data.pop(self._actor_key).actor_id)
+
+    def get_provider_id(self, validated_data: MutableMapping[str, Any]) -> int:
+        provider_name_option = validated_data.pop("provider", None)
+        provider = validate_provider(provider_name_option, available_providers=AVAILABLE_PROVIDERS)
+        return int(provider.value)
+
+    def create(self, validated_data: MutableMapping[str, Any]) -> ExternalActor:
+        actor_id = self.get_actor_id(validated_data)
+        provider = self.get_provider_id(validated_data)
+
+        return ExternalActor.objects.get_or_create(
+            **validated_data,
+            actor_id=actor_id,
+            provider=provider,
+            organization=self.organization,
+        )
+
+    def update(
+        self, instance: ExternalActor, validated_data: MutableMapping[str, Any]
+    ) -> ExternalActor:
+        # Discard the object ID passed by the API.
+        if "id" in validated_data:
+            validated_data.pop("id")
+
+        for key, value in validated_data.items():
+            setattr(self.instance, key, value)
+        try:
+            self.instance.save()
+            return self.instance
+        except IntegrityError:
+            raise serializers.ValidationError(
+                "There already exists an external association with this external_name and provider."
+            )
+
+
+class ExternalUserSerializer(ExternalActorSerializerBase):
+    _actor_key = "user_id"
+
+    user_id = serializers.IntegerField(required=True)
+
+    def validate_user_id(self, user_id: int) -> User:
+        """ Ensure that this user exists and that they belong to the organization. """
+
+        try:
+            return User.objects.get(
+                id=user_id, sentry_orgmember_set__organization=self.organization
+            )
+        except User.DoesNotExist:
+            raise serializers.ValidationError("This member does not exist.")
+
+    class Meta:
+        model = ExternalActor
+        fields = ["user_id", "external_name", "provider"]
+
+
+class ExternalTeamSerializer(ExternalActorSerializerBase):
+    _actor_key = "team_id"
+
+    team_id = serializers.IntegerField(required=True)
+
+    def validate_team_id(self, team_id: int) -> Team:
+        """ Ensure that this team exists and that they belong to the organization. """
+        try:
+            return Team.objects.get(id=team_id, organization=self.organization)
+        except Team.DoesNotExist:
+            raise serializers.ValidationError("This team does not exist.")
+
+    class Meta:
+        model = ExternalActor
+        fields = ["team_id", "external_name", "provider"]
+
+
+class ExternalActorEndpointMixin:
+    @staticmethod
+    def has_feature(request: Request, organization: Organization) -> bool:
+        return bool(
+            features.has("organizations:import-codeowners", organization, actor=request.user)
+        )
+
+    def assert_has_feature(self, request: Request, organization: Organization) -> None:
+        if not self.has_feature(request, organization):
+            raise PermissionDenied
+
+    @staticmethod
+    def get_external_actor_or_404(external_actor_id: int) -> ExternalActor:
+        try:
+            return ExternalActor.objects.get(id=external_actor_id)
+        except ExternalActor.DoesNotExist:
+            raise Http404

--- a/src/sentry/api/endpoints/external_team.py
+++ b/src/sentry/api/endpoints/external_team.py
@@ -1,64 +1,19 @@
 import logging
 
-from django.db import IntegrityError
-from rest_framework import serializers, status
-from rest_framework.exceptions import PermissionDenied
-from rest_framework.response import Response
+from rest_framework import status  # type: ignore
+from rest_framework.request import Request  # type: ignore
+from rest_framework.response import Response  # type: ignore
 
-from sentry import features
+from sentry.api.bases.external_actor import ExternalActorEndpointMixin, ExternalTeamSerializer
 from sentry.api.bases.team import TeamEndpoint
 from sentry.api.serializers import serialize
-from sentry.api.serializers.rest_framework.base import CamelSnakeModelSerializer
-from sentry.models import ExternalTeam
-from sentry.types.integrations import EXTERNAL_PROVIDERS, ExternalProviders, get_provider_enum
+from sentry.models import Team
 
 logger = logging.getLogger(__name__)
 
 
-class ExternalTeamSerializer(CamelSnakeModelSerializer):
-    team_id = serializers.IntegerField(required=True)
-    external_name = serializers.CharField(required=True)
-    provider = serializers.ChoiceField(choices=list(EXTERNAL_PROVIDERS.values()))
-
-    class Meta:
-        model = ExternalTeam
-        fields = ["team_id", "external_name", "provider"]
-
-    def validate_provider(self, provider: str) -> int:
-        provider_option = get_provider_enum(provider)
-        if provider_option in [ExternalProviders.GITHUB, ExternalProviders.GITLAB]:
-            return provider_option.value
-
-        raise serializers.ValidationError(
-            f'The provider "{provider}" is not supported. We currently accept GitHub and GitLab team identities.'
-        )
-
-    def create(self, validated_data):
-        return ExternalTeam.objects.get_or_create(**validated_data)
-
-    def update(self, instance, validated_data):
-        if "id" in validated_data:
-            validated_data.pop("id")
-        for key, value in validated_data.items():
-            setattr(self.instance, key, value)
-        try:
-            self.instance.save()
-            return self.instance
-        except IntegrityError:
-            raise serializers.ValidationError(
-                "There already exists an external team association with this external_name and provider."
-            )
-
-
-class ExternalTeamMixin:
-    def has_feature(self, request, team):
-        return features.has(
-            "organizations:import-codeowners", team.organization, actor=request.user
-        )
-
-
-class ExternalTeamEndpoint(TeamEndpoint, ExternalTeamMixin):
-    def post(self, request, team):
+class ExternalTeamEndpoint(TeamEndpoint, ExternalActorEndpointMixin):  # type: ignore
+    def post(self, request: Request, team: Team) -> Response:
         """
         Create an External Team
         `````````````
@@ -70,13 +25,14 @@ class ExternalTeamEndpoint(TeamEndpoint, ExternalTeamMixin):
         :param required string external_name: the associated Github/Gitlab team name.
         :auth: required
         """
-        if not self.has_feature(request, team):
-            raise PermissionDenied
+        self.assert_has_feature(request, team.organization)
 
-        serializer = ExternalTeamSerializer(data={**request.data, "team_id": team.id})
-        if serializer.is_valid():
-            external_team, created = serializer.save()
-            status_code = status.HTTP_201_CREATED if created else status.HTTP_200_OK
-            return Response(serialize(external_team, request.user), status=status_code)
+        serializer = ExternalTeamSerializer(
+            data={**request.data, "team_id": team.id}, context={"organization": team.organization}
+        )
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+        external_team, created = serializer.save()
+        status_code = status.HTTP_201_CREATED if created else status.HTTP_200_OK
+        return Response(serialize(external_team, request.user, key="team"), status=status_code)

--- a/src/sentry/api/endpoints/external_team_details.py
+++ b/src/sentry/api/endpoints/external_team_details.py
@@ -1,34 +1,34 @@
 import logging
+from typing import Any, Tuple
 
-from django.http import Http404
-from rest_framework import status
-from rest_framework.exceptions import PermissionDenied
-from rest_framework.response import Response
+from rest_framework import status  # type: ignore
+from rest_framework.request import Request  # type: ignore
+from rest_framework.response import Response  # type: ignore
 
+from sentry.api.bases.external_actor import ExternalActorEndpointMixin, ExternalTeamSerializer
 from sentry.api.bases.team import TeamEndpoint
 from sentry.api.serializers import serialize
-from sentry.models import ExternalTeam
-
-from .external_team import ExternalTeamMixin, ExternalTeamSerializer
+from sentry.models import ExternalActor, Team
 
 logger = logging.getLogger(__name__)
 
 
-class ExternalTeamDetailsEndpoint(TeamEndpoint, ExternalTeamMixin):
+class ExternalTeamDetailsEndpoint(TeamEndpoint, ExternalActorEndpointMixin):  # type: ignore
     def convert_args(
-        self, request, organization_slug, team_slug, external_team_id, *args, **kwargs
-    ):
+        self,
+        request: Request,
+        organization_slug: str,
+        team_slug: str,
+        external_team_id: int,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Tuple[Any, Any]:
         args, kwargs = super().convert_args(request, organization_slug, team_slug, *args, **kwargs)
-        try:
-            kwargs["external_team"] = ExternalTeam.objects.get(
-                id=external_team_id,
-            )
-        except ExternalTeam.DoesNotExist:
-            raise Http404
 
-        return (args, kwargs)
+        kwargs["external_team"] = self.get_external_actor_or_404(external_team_id)
+        return args, kwargs
 
-    def put(self, request, team, external_team):
+    def put(self, request: Request, team: Team, external_team: ExternalActor) -> Response:
         """
         Update an External Team
         `````````````
@@ -41,11 +41,13 @@ class ExternalTeamDetailsEndpoint(TeamEndpoint, ExternalTeamMixin):
         :param string provider: enum("github","gitlab")
         :auth: required
         """
-        if not self.has_feature(request, team):
-            raise PermissionDenied
+        self.assert_has_feature(request, team.organization)
 
         serializer = ExternalTeamSerializer(
-            instance=external_team, data={**request.data, "team_id": team.id}, partial=True
+            instance=external_team,
+            data={**request.data, "team_id": team.id},
+            partial=True,
+            context={"organization": team.organization},
         )
         if serializer.is_valid():
             updated_external_team = serializer.save()
@@ -56,12 +58,11 @@ class ExternalTeamDetailsEndpoint(TeamEndpoint, ExternalTeamMixin):
 
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-    def delete(self, request, team, external_team):
+    def delete(self, request: Request, team: Team, external_team: ExternalActor) -> Response:
         """
         Delete an External Team
         """
-        if not self.has_feature(request, team):
-            raise PermissionDenied
+        self.assert_has_feature(request, team.organization)
 
         external_team.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/src/sentry/api/endpoints/external_user.py
+++ b/src/sentry/api/endpoints/external_user.py
@@ -1,93 +1,38 @@
 import logging
 
-from django.db import IntegrityError
-from rest_framework import serializers, status
-from rest_framework.exceptions import PermissionDenied
-from rest_framework.response import Response
+from rest_framework import status  # type: ignore
+from rest_framework.request import Request  # type: ignore
+from rest_framework.response import Response  # type: ignore
 
-from sentry import features
-from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.api.bases import OrganizationEndpoint
+from sentry.api.bases.external_actor import ExternalActorEndpointMixin, ExternalUserSerializer
 from sentry.api.serializers import serialize
-from sentry.api.serializers.rest_framework.base import CamelSnakeModelSerializer
-from sentry.models import ExternalUser, OrganizationMember
-from sentry.types.integrations import EXTERNAL_PROVIDERS, ExternalProviders, get_provider_enum
+from sentry.models import Organization
 
 logger = logging.getLogger(__name__)
 
 
-class ExternalUserSerializer(CamelSnakeModelSerializer):
-    member_id = serializers.IntegerField(required=True)
-    external_name = serializers.CharField(required=True)
-    provider = serializers.ChoiceField(choices=list(EXTERNAL_PROVIDERS.values()))
-
-    class Meta:
-        model = ExternalUser
-        fields = ["member_id", "external_name", "provider"]
-
-    def validate_provider(self, provider: str) -> int:
-        provider_option = get_provider_enum(provider)
-        if provider_option in [ExternalProviders.GITHUB, ExternalProviders.GITLAB]:
-            return provider_option.value
-
-        raise serializers.ValidationError(
-            f'The provider "{provider}" is not supported. We currently accept GitHub and GitLab user identities.'
-        )
-
-    def validate_member_id(self, member_id):
-        try:
-            return OrganizationMember.objects.get(
-                id=member_id, organization=self.context["organization"]
-            )
-        except OrganizationMember.DoesNotExist:
-            raise serializers.ValidationError("This member does not exist.")
-
-    def create(self, validated_data):
-        organizationmember = validated_data.pop("member_id", None)
-        return ExternalUser.objects.get_or_create(
-            organizationmember=organizationmember, **validated_data
-        )
-
-    def update(self, instance, validated_data):
-        if "id" in validated_data:
-            validated_data.pop("id")
-        for key, value in validated_data.items():
-            setattr(self.instance, key, value)
-        try:
-            self.instance.save()
-            return self.instance
-        except IntegrityError:
-            raise serializers.ValidationError(
-                "There already exists an external user association with this external_name and provider."
-            )
-
-
-class ExternalUserMixin:
-    def has_feature(self, request, organization):
-        return features.has("organizations:import-codeowners", organization, actor=request.user)
-
-
-class ExternalUserEndpoint(OrganizationEndpoint, ExternalUserMixin):
-    def post(self, request, organization):
+class ExternalUserEndpoint(OrganizationEndpoint, ExternalActorEndpointMixin):  # type: ignore
+    def post(self, request: Request, organization: Organization) -> Response:
         """
         Create an External User
         `````````````
 
         :pparam string organization_slug: the slug of the organization the
                                           user belongs to.
-        :param required string provider: enum("github", "gitlab")
+        :param required string provider: enum("github", "gitlab", "slack")
         :param required string external_name: the associated Github/Gitlab user name.
-        :param required int member_id: the organization_member id.
+        :param required int user_id: the User id.
         :auth: required
         """
-        if not self.has_feature(request, organization):
-            raise PermissionDenied
+        self.assert_has_feature(request, organization)
 
         serializer = ExternalUserSerializer(
-            context={"organization": organization}, data={**request.data}
+            data=request.data, context={"organization": organization}
         )
-        if serializer.is_valid():
-            external_user, created = serializer.save()
-            status_code = status.HTTP_201_CREATED if created else status.HTTP_200_OK
-            return Response(serialize(external_user, request.user), status=status_code)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+        external_user, created = serializer.save()
+        status_code = status.HTTP_201_CREATED if created else status.HTTP_200_OK
+        return Response(serialize(external_user, request.user, key="user"), status=status_code)

--- a/src/sentry/api/endpoints/external_user_details.py
+++ b/src/sentry/api/endpoints/external_user_details.py
@@ -1,46 +1,47 @@
 import logging
+from typing import Any, Tuple
 
-from django.http import Http404
-from rest_framework import status
-from rest_framework.exceptions import PermissionDenied
-from rest_framework.response import Response
+from rest_framework import status  # type: ignore
+from rest_framework.request import Request  # type: ignore
+from rest_framework.response import Response  # type: ignore
 
+from sentry.api.bases.external_actor import ExternalActorEndpointMixin, ExternalUserSerializer
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.serializers import serialize
-from sentry.models import ExternalUser
-
-from .external_user import ExternalUserMixin, ExternalUserSerializer
+from sentry.models import ExternalActor, Organization
 
 logger = logging.getLogger(__name__)
 
 
-class ExternalUserDetailsEndpoint(OrganizationEndpoint, ExternalUserMixin):
-    def convert_args(self, request, organization_slug, external_user_id, *args, **kwargs):
+class ExternalUserDetailsEndpoint(OrganizationEndpoint, ExternalActorEndpointMixin):  # type: ignore
+    def convert_args(
+        self,
+        request: Request,
+        organization_slug: str,
+        external_user_id: int,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Tuple[Any, Any]:
         args, kwargs = super().convert_args(request, organization_slug, *args, **kwargs)
-        try:
-            kwargs["external_user"] = ExternalUser.objects.get(
-                id=external_user_id,
-            )
-        except ExternalUser.DoesNotExist:
-            raise Http404
+        kwargs["external_user"] = self.get_external_actor_or_404(external_user_id)
+        return args, kwargs
 
-        return (args, kwargs)
-
-    def put(self, request, organization, external_user):
+    def put(
+        self, request: Request, organization: Organization, external_user: ExternalActor
+    ) -> Response:
         """
         Update an External User
         `````````````
 
         :pparam string organization_slug: the slug of the organization the
                                           user belongs to.
-        :pparam int user_id: the organization_member id.
+        :pparam int user_id: the User id.
         :pparam string external_user_id: id of external_user object
         :param string external_name: the Github/Gitlab user name.
         :param string provider: enum("github","gitlab")
         :auth: required
         """
-        if not self.has_feature(request, organization):
-            raise PermissionDenied
+        self.assert_has_feature(request, organization)
 
         serializer = ExternalUserSerializer(
             instance=external_user,
@@ -57,12 +58,13 @@ class ExternalUserDetailsEndpoint(OrganizationEndpoint, ExternalUserMixin):
 
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-    def delete(self, request, organization, external_user):
+    def delete(
+        self, request: Request, organization: Organization, external_user: ExternalActor
+    ) -> Response:
         """
         Delete an External Team
         """
-        if not self.has_feature(request, organization):
-            raise PermissionDenied
+        self.assert_has_feature(request, organization)
 
         external_user.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/src/sentry/api/endpoints/organization_invite_request_details.py
+++ b/src/sentry/api/endpoints/organization_invite_request_details.py
@@ -6,7 +6,8 @@ from rest_framework.response import Response
 from sentry import features, roles
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.api.serializers import OrganizationMemberWithTeamsSerializer, serialize
+from sentry.api.serializers import serialize
+from sentry.api.serializers.models.organization_member import OrganizationMemberWithTeamsSerializer
 from sentry.models import AuditLogEntryEvent, InviteStatus, OrganizationMember
 from sentry.signals import member_invited
 

--- a/src/sentry/api/endpoints/organization_invite_request_index.py
+++ b/src/sentry/api/endpoints/organization_invite_request_index.py
@@ -5,7 +5,8 @@ from rest_framework.response import Response
 from sentry import roles
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.api.paginator import OffsetPaginator
-from sentry.api.serializers import OrganizationMemberWithTeamsSerializer, serialize
+from sentry.api.serializers import serialize
+from sentry.api.serializers.models.organization_member import OrganizationMemberWithTeamsSerializer
 from sentry.app import locks
 from sentry.models import AuditLogEntryEvent, InviteStatus, OrganizationMember
 from sentry.tasks.members import send_invite_request_notification_email

--- a/src/sentry/api/serializers/models/external_actor.py
+++ b/src/sentry/api/serializers/models/external_actor.py
@@ -1,0 +1,71 @@
+from collections import defaultdict
+from typing import Any, List, Mapping, MutableMapping, Optional
+
+from sentry.api.serializers import Serializer, register
+from sentry.models import (
+    ACTOR_TYPES,
+    ExternalActor,
+    User,
+    actor_type_to_class,
+    actor_type_to_string,
+)
+from sentry.types.integrations import get_provider_string
+
+
+@register(ExternalActor)
+class ExternalActorSerializer(Serializer):  # type: ignore
+    def get_attrs(
+        self, item_list: List[ExternalActor], user: User, **kwargs: Any
+    ) -> MutableMapping[Any, Any]:
+        external_actors_by_actor_id = {
+            external_actor.actor_id: external_actor for external_actor in item_list
+        }
+
+        actor_ids_by_type = defaultdict(list)
+        for actor_id, external_actor in external_actors_by_actor_id.items():
+            if actor_id is not None:
+                type_str = actor_type_to_string(external_actor.actor.type)
+                actor_ids_by_type[type_str].append(actor_id)
+
+        resolved_actors_by_type: MutableMapping[str, Mapping[int, int]] = defaultdict(dict)
+        for type_str, type_id in ACTOR_TYPES.items():
+            klass = actor_type_to_class(type_id)
+            actor_ids = actor_ids_by_type[type_str]
+
+            resolved_actors = klass.objects.filter(actor_id__in=actor_ids)
+
+            resolved_actors_by_type[type_str] = {model.actor_id: model for model in resolved_actors}
+
+        results: MutableMapping[ExternalActor, MutableMapping[str, Any]] = defaultdict(dict)
+        for type_str, mapping in resolved_actors_by_type.items():
+            for actor_id, model in mapping.items():
+                external_actor = external_actors_by_actor_id[actor_id]
+                results[external_actor][type_str] = model
+
+        return results
+
+    def serialize(
+        self,
+        obj: ExternalActor,
+        attrs: Mapping[str, Any],
+        user: User,
+        key: Optional[str] = None,
+        **kwargs: Any,
+    ) -> Mapping[str, Any]:
+        provider = get_provider_string(obj.provider)
+        data = {
+            "id": str(obj.id),
+            "provider": provider,
+            "externalName": obj.external_name,
+        }
+
+        if obj.external_id:
+            data["externalId"] = obj.external_id
+
+        # Extra context `key` tells the API how to resolve actor_id.
+        if key == "user":
+            data["userId"] = str(attrs[key].id)
+        elif key == "team":
+            data["teamId"] = str(attrs[key].id)
+
+        return data

--- a/src/sentry/api/serializers/models/integration.py
+++ b/src/sentry/api/serializers/models/integration.py
@@ -6,8 +6,6 @@ from sentry.api.serializers import Serializer, register, serialize
 from sentry.integrations import IntegrationProvider
 from sentry.models import (
     ExternalIssue,
-    ExternalTeam,
-    ExternalUser,
     Group,
     GroupLink,
     Integration,
@@ -15,7 +13,6 @@ from sentry.models import (
     User,
 )
 from sentry.shared_integrations.exceptions import ApiError
-from sentry.types.integrations import get_provider_string
 from sentry.utils.json import JSONData
 
 logger = logging.getLogger(__name__)
@@ -239,31 +236,3 @@ class IntegrationIssueSerializer(IntegrationSerializer):
         data = super().serialize(obj, attrs, user)
         data["externalIssues"] = attrs.get("external_issues", [])
         return data
-
-
-@register(ExternalTeam)
-class ExternalTeamSerializer(Serializer):  # type: ignore
-    def serialize(
-        self, obj: Any, attrs: Mapping[str, Any], user: User, **kwargs: Any
-    ) -> MutableMapping[str, JSONData]:
-        provider = get_provider_string(obj.provider)
-        return {
-            "id": str(obj.id),
-            "teamId": str(obj.team_id),
-            "provider": provider,
-            "externalName": obj.external_name,
-        }
-
-
-@register(ExternalUser)
-class ExternalUserSerializer(Serializer):  # type: ignore
-    def serialize(
-        self, obj: Any, attrs: Mapping[str, Any], user: User, **kwargs: Any
-    ) -> MutableMapping[str, JSONData]:
-        provider = get_provider_string(obj.provider)
-        return {
-            "id": str(obj.id),
-            "memberId": str(obj.organizationmember_id),
-            "provider": provider,
-            "externalName": obj.external_name,
-        }

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -1001,12 +1001,12 @@ urlpatterns = [
                     name="sentry-api-0-organization-member-index",
                 ),
                 url(
-                    r"^(?P<organization_slug>[^\/]+)/members/externaluser/$",
+                    r"^(?P<organization_slug>[^\/]+)/external-users/$",
                     ExternalUserEndpoint.as_view(),
                     name="sentry-api-0-organization-external-user",
                 ),
                 url(
-                    r"^(?P<organization_slug>[^\/]+)/members/externaluser/(?P<external_user_id>[^\/]+)/$",
+                    r"^(?P<organization_slug>[^\/]+)/external-users/(?P<external_user_id>[^\/]+)/$",
                     ExternalUserDetailsEndpoint.as_view(),
                     name="sentry-api-0-organization-external-user-details",
                 ),
@@ -1361,12 +1361,12 @@ urlpatterns = [
                     name="sentry-api-0-team-avatar",
                 ),
                 url(
-                    r"^(?P<organization_slug>[^\/]+)/(?P<team_slug>[^\/]+)/externalteam/$",
+                    r"^(?P<organization_slug>[^\/]+)/(?P<team_slug>[^\/]+)/external-teams/$",
                     ExternalTeamEndpoint.as_view(),
                     name="sentry-api-0-external-team",
                 ),
                 url(
-                    r"^(?P<organization_slug>[^\/]+)/(?P<team_slug>[^\/]+)/externalteam/(?P<external_team_id>[^\/]+)/$",
+                    r"^(?P<organization_slug>[^\/]+)/(?P<team_slug>[^\/]+)/external-teams/(?P<external_team_id>[^\/]+)/$",
                     ExternalTeamDetailsEndpoint.as_view(),
                     name="sentry-api-0-external-team-details",
                 ),

--- a/src/sentry/api/validators/integrations.py
+++ b/src/sentry/api/validators/integrations.py
@@ -1,0 +1,25 @@
+from typing import List, Optional, Set
+
+from sentry.api.exceptions import ParameterValidationError
+from sentry.types.integrations import ExternalProviders, get_provider_enum
+
+
+def validate_provider(
+    provider: str,
+    available_providers: Optional[Set[ExternalProviders]] = None,
+    context: Optional[List[str]] = None,
+) -> ExternalProviders:
+    provider_option = get_provider_enum(provider)
+    if not provider_option:
+        raise ParameterValidationError(f"Unknown provider: {provider}", context)
+
+    # If not available_providers are provider, assume all are acceptable
+    if available_providers and provider_option not in available_providers:
+        raise ParameterValidationError(
+            f'The provider "{provider}" is not supported. We currently accept {available_providers} identities.'
+        )
+    return provider_option
+
+
+def validate_provider_option(provider: Optional[str]) -> Optional[ExternalProviders]:
+    return validate_provider(provider) if provider else None

--- a/src/sentry/api/validators/notifications.py
+++ b/src/sentry/api/validators/notifications.py
@@ -1,13 +1,14 @@
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Set, Tuple, Union
 
 from sentry.api.exceptions import ParameterValidationError
+from sentry.api.validators.integrations import validate_provider
 from sentry.notifications.helpers import validate as helper_validate
 from sentry.notifications.types import (
     NotificationScopeType,
     NotificationSettingOptionValues,
     NotificationSettingTypes,
 )
-from sentry.types.integrations import ExternalProviders, get_provider_enum
+from sentry.types.integrations import ExternalProviders
 
 
 def intersect_dict_set(d: Dict[int, Any], s: Set[int]) -> Dict[int, Any]:
@@ -64,10 +65,6 @@ def validate_type_option(type: Optional[str]) -> Optional[NotificationSettingTyp
     return validate_type(type) if type else None
 
 
-def validate_provider_option(provider: Optional[str]) -> Optional[ExternalProviders]:
-    return validate_provider(provider) if provider else None
-
-
 def validate_type(type: str, context: Optional[List[str]] = None) -> NotificationSettingTypes:
     try:
         return NotificationSettingTypes(type)
@@ -98,13 +95,6 @@ def validate_scope(
         return int(scope_id)
     except ValueError:
         raise ParameterValidationError(f"Invalid ID: {scope_id}", context)
-
-
-def validate_provider(provider: str, context: Optional[List[str]] = None) -> ExternalProviders:
-    provider_option = get_provider_enum(provider)
-    if provider_option:
-        return provider_option
-    raise ParameterValidationError(f"Unknown provider: {provider}", context)
 
 
 def validate_value(
@@ -171,7 +161,7 @@ def validate(
 
                 context = parent_context + [type_key, scope_type_key, str(scope_id)]
                 for provider_key, value_key in notifications_by_scope_id.items():
-                    provider = validate_provider(provider_key, context)
+                    provider = validate_provider(provider_key, context=context)
                     value = validate_value(type, value_key, context)
 
                     notification_settings_to_update[(type, scope_type, scope_id, provider)] = value

--- a/src/sentry/ownership/grammar.py
+++ b/src/sentry/ownership/grammar.py
@@ -1,5 +1,6 @@
 import re
 from collections import namedtuple
+from typing import List, Tuple
 
 from parsimonious.exceptions import ParseError  # noqa
 from parsimonious.grammar import Grammar, NodeVisitor
@@ -236,7 +237,7 @@ def load_schema(schema):
     return [Rule.load(r) for r in schema["rules"]]
 
 
-def parse_code_owners(data):
+def parse_code_owners(data: str) -> Tuple[List[str], List[str], List[str]]:
     """Parse a CODEOWNERS text and returns the list of team names, list of usernames"""
     teams = []
     usernames = []

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -5,6 +5,7 @@ import warnings
 from binascii import hexlify
 from hashlib import sha1
 from importlib import import_module
+from typing import Any
 from uuid import uuid4
 
 import petname
@@ -46,9 +47,8 @@ from sentry.models import (
     CommitFileChange,
     Environment,
     EventAttachment,
+    ExternalActor,
     ExternalIssue,
-    ExternalTeam,
-    ExternalUser,
     File,
     Group,
     GroupLink,
@@ -954,18 +954,18 @@ class Factories:
         )
 
     @staticmethod
-    def create_external_user(organizationmember, **kwargs):
+    def create_external_user(user: User, **kwargs: Any) -> ExternalActor:
         kwargs.setdefault("provider", ExternalProviders.GITHUB.value)
         kwargs.setdefault("external_name", "")
 
-        return ExternalUser.objects.create(organizationmember=organizationmember, **kwargs)
+        return ExternalActor.objects.create(actor=user.actor, **kwargs)
 
     @staticmethod
-    def create_external_team(team, **kwargs):
+    def create_external_team(team: Team, **kwargs: Any) -> ExternalActor:
         kwargs.setdefault("provider", ExternalProviders.GITHUB.value)
         kwargs.setdefault("external_name", "@getsentry/ecosystem")
 
-        return ExternalTeam.objects.create(team=team, **kwargs)
+        return ExternalActor.objects.create(actor=team.actor, **kwargs)
 
     @staticmethod
     def create_codeowners(project, code_mapping, **kwargs):

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -297,15 +297,14 @@ class Fixtures:
         if not user:
             user = self.user
         if not organization:
-            organization = self.organization
+            organization = self.organization  # Force creation.
 
-        organizationmember = OrganizationMember.objects.get(user=user, organization=organization)
-        return Factories.create_external_user(organizationmember=organizationmember, **kwargs)
+        return Factories.create_external_user(user=user, organization=organization, **kwargs)
 
     def create_external_team(self, team=None, **kwargs):
         if not team:
             team = self.team
-        return Factories.create_external_team(team=team, **kwargs)
+        return Factories.create_external_team(team=team, organization=team.organization, **kwargs)
 
     def create_codeowners(self, project=None, code_mapping=None, **kwargs):
         if not project:

--- a/src/sentry/types/integrations.py
+++ b/src/sentry/types/integrations.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Optional
+from typing import Optional, Sequence, Set
 
 
 class ExternalProviders(Enum):
@@ -34,3 +34,7 @@ def get_provider_string(provider_int: int) -> str:
 
 def get_provider_enum(value: Optional[str]) -> Optional[ExternalProviders]:
     return {v: k for k, v in EXTERNAL_PROVIDERS.items()}.get(value)
+
+
+def get_provider_choices(providers: Set[ExternalProviders]) -> Sequence[str]:
+    return list(EXTERNAL_PROVIDERS.get(i) for i in providers)

--- a/tests/sentry/api/endpoints/test_external_team.py
+++ b/tests/sentry/api/endpoints/test_external_team.py
@@ -1,6 +1,5 @@
-from sentry.models import ExternalTeam
 from sentry.testutils import APITestCase
-from sentry.types.integrations import ExternalProviders, get_provider_string
+from sentry.types.integrations import get_provider_string
 
 
 class ExternalTeamTest(APITestCase):
@@ -55,10 +54,8 @@ class ExternalTeamTest(APITestCase):
         assert response.data == {"provider": ['"git" is not a valid choice.']}
 
     def test_create_existing_association(self):
-        self.external_team = ExternalTeam.objects.create(
-            team_id=str(self.team.id),
-            provider=ExternalProviders.GITHUB.value,
-            external_name="@getsentry/ecosystem",
+        self.external_team = self.create_external_team(
+            self.team, external_name="@getsentry/ecosystem"
         )
         data = {
             "externalName": self.external_team.external_name,
@@ -68,6 +65,6 @@ class ExternalTeamTest(APITestCase):
             response = self.get_success_response(self.organization.slug, self.team.slug, **data)
         assert response.data == {
             "id": str(self.external_team.id),
-            "teamId": str(self.external_team.team_id),
+            "teamId": str(self.team.id),
             **data,
         }

--- a/tests/sentry/api/endpoints/test_external_team_details.py
+++ b/tests/sentry/api/endpoints/test_external_team_details.py
@@ -1,6 +1,5 @@
-from sentry.models import ExternalTeam
+from sentry.models import ExternalActor
 from sentry.testutils import APITestCase
-from sentry.types.integrations import ExternalProviders
 
 
 class ExternalTeamDetailsTest(APITestCase):
@@ -10,10 +9,9 @@ class ExternalTeamDetailsTest(APITestCase):
     def setUp(self):
         super().setUp()
         self.login_as(self.user)
-        self.external_team = ExternalTeam.objects.create(
-            team_id=str(self.team.id),
-            provider=ExternalProviders.GITHUB.value,
-            external_name="@getsentry/ecosystem",
+
+        self.external_team = self.create_external_team(
+            self.team, external_name="@getsentry/ecosystem"
         )
 
     def test_basic_delete(self):
@@ -21,7 +19,7 @@ class ExternalTeamDetailsTest(APITestCase):
             self.get_success_response(
                 self.organization.slug, self.team.slug, self.external_team.id, method="delete"
             )
-        assert not ExternalTeam.objects.filter(id=str(self.external_team.id)).exists()
+        assert not ExternalActor.objects.filter(id=str(self.external_team.id)).exists()
 
     def test_basic_update(self):
         with self.feature({"organizations:import-codeowners": True}):

--- a/tests/sentry/api/endpoints/test_external_user_details.py
+++ b/tests/sentry/api/endpoints/test_external_user_details.py
@@ -1,4 +1,4 @@
-from sentry.models import ExternalUser
+from sentry.models import ExternalActor
 from sentry.testutils import APITestCase
 
 
@@ -18,7 +18,7 @@ class ExternalUserDetailsTest(APITestCase):
             self.get_success_response(
                 self.organization.slug, self.external_user.id, method="delete"
             )
-        assert not ExternalUser.objects.filter(id=str(self.external_user.id)).exists()
+        assert not ExternalActor.objects.filter(id=str(self.external_user.id)).exists()
 
     def test_basic_update(self):
         with self.feature({"organizations:import-codeowners": True}):

--- a/tests/sentry/api/endpoints/test_organization_member_index.py
+++ b/tests/sentry/api/endpoints/test_organization_member_index.py
@@ -475,24 +475,36 @@ class OrganizationMemberListTest(APITestCase):
         assert len(mail.outbox) == 1
 
     def test_user_has_external_user_association(self):
+        print("user.id", self.user.id)
+        print("user2.id", self.user_2.id)
+        print("external_user", self.external_user.id)
+
         response = self.get_valid_response(self.org.slug, qs_params={"expand": "externalUsers"})
         assert len(response.data) == 2
-        member = next(filter(lambda x: x["user"]["id"] == str(self.user_2.id), response.data))
-        assert member
-        assert len(member["externalUsers"]) == 1
-        assert member["externalUsers"][0]["id"] == str(self.external_user.id)
-        assert member["externalUsers"][0]["memberId"] == member["id"]
+        organization_member = next(
+            filter(lambda x: x["user"]["id"] == str(self.user_2.id), response.data)
+        )
+        assert organization_member
+        assert len(organization_member["externalUsers"]) == 1
+        assert organization_member["externalUsers"][0]["id"] == str(self.external_user.id)
+        assert (
+            organization_member["externalUsers"][0]["userId"] == organization_member["user"]["id"]
+        )
 
     def test_user_has_external_user_associations_across_multiple_orgs(self):
         self.org_2 = self.create_organization(owner=self.user_2)
         self.external_user_2 = self.create_external_user(self.user_2, self.org_2)
         response = self.get_valid_response(self.org.slug, qs_params={"expand": "externalUsers"})
         assert len(response.data) == 2
-        member = next(filter(lambda x: x["user"]["id"] == str(self.user_2.id), response.data))
-        assert member
-        assert len(member["externalUsers"]) == 1
-        assert member["externalUsers"][0]["id"] == str(self.external_user.id)
-        assert member["externalUsers"][0]["memberId"] == member["id"]
+        organization_member = next(
+            filter(lambda x: x["user"]["id"] == str(self.user_2.id), response.data)
+        )
+        assert organization_member
+        assert len(organization_member["externalUsers"]) == 1
+        assert organization_member["externalUsers"][0]["id"] == str(self.external_user.id)
+        assert (
+            organization_member["externalUsers"][0]["userId"] == organization_member["user"]["id"]
+        )
 
 
 class OrganizationMemberListPostTest(APITestCase):

--- a/tests/sentry/api/serializers/test_external_actor.py
+++ b/tests/sentry/api/serializers/test_external_actor.py
@@ -1,0 +1,49 @@
+from sentry.api.serializers import serialize
+from sentry.models import ExternalActor
+from sentry.testutils import TestCase
+from sentry.types.integrations import ExternalProviders
+
+
+class ExternalActorSerializerTest(TestCase):
+    def test_user(self):
+        user = self.create_user()
+        organization = self.create_organization(owner=user)
+
+        external_actor, _ = ExternalActor.objects.get_or_create(
+            actor_id=user.actor_id,
+            organization=organization,
+            integration=None,
+            provider=ExternalProviders.SLACK.value,
+            external_name="Marcos",
+            external_id="Gaeta",
+        )
+
+        result = serialize(external_actor, user, key="user")
+
+        assert "actorId" not in result
+        assert result["id"] == str(external_actor.id)
+        assert result["externalName"] == "Marcos"
+        assert result["externalId"] == "Gaeta"
+        assert result["userId"] == str(user.id)
+
+    def test_team(self):
+        user = self.create_user()
+        organization = self.create_organization(owner=user)
+        team = self.create_team(organization=organization, members=[self.user])
+
+        external_actor, _ = ExternalActor.objects.get_or_create(
+            actor_id=team.actor_id,
+            organization=organization,
+            integration=None,
+            provider=ExternalProviders.SLACK.value,
+            external_name="Marcos",
+            external_id="Gaeta",
+        )
+
+        result = serialize(external_actor, user, key="team")
+
+        assert "actorId" not in result
+        assert result["id"] == str(external_actor.id)
+        assert result["externalName"] == "Marcos"
+        assert result["externalId"] == "Gaeta"
+        assert result["teamId"] == str(team.id)


### PR DESCRIPTION
# Summary

Moved External team/user duplicate logic + to External Actor singular logic (which handles both users/teams(/organizations)
Adapted External Team/User endpoints to new logic
Small fixes were made along the way where needed, as well as tests

# [Start CR](https://github.com/GerevSec/sentry/pull/2/commits/6fe2c6e80d6d328c986067f34c6cd54e4f410d38)